### PR TITLE
Jscc jquery

### DIFF
--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -490,7 +490,6 @@ Avoid minification through obfuscation and try to make your code more human read
 ##### Caching jQuery Objects
 
 Reduce the number of DOM queries by caching jQuery objects if the same object will be used more than once. Prefix jQuery object variables with a `$`.
-
 ```javascript
 // bad
 if ($('#foo').is(':visible')) {


### PR DESCRIPTION
This explains caching as well as prefixing jQuery vars, while before it was just prefixing. 

@BladeBronson @kenkouot @RafLeszczynski @hakubo 
