### PR TITLE
Prefer dot notation

### DIFF
--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -297,6 +297,14 @@ var map = {
 	'you are': 15
 };
 ```
+When accessing object properties, dot notation is preferred over brackets. 
+```js
+// Bad
+myObj['someProp'];
+
+// Good
+myObj.someProp;
+```
 
 #### Arrays
 


### PR DESCRIPTION
per @jsutterfield's comment, adding dot notation preference to guidelines. It is already checked as part of JSHint but now it will be explicitly stated in the guidelines. 

@kenkouot @BladeBronson 
