### PR TITLE
Don't run pylint if no Python files have changed

### DIFF
--- a/githooks/pre-commit.d/py-20-pylint
+++ b/githooks/pre-commit.d/py-20-pylint
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# if no python files have changed, don't run pylint
+FILES=$(printf "%s\n" $@ | grep ".*\.py$")
+if [[ -z "$FILES" ]]; then
+  exit 0
+fi
+
 # we need to run pylint on all files, because has certain "global"
 # checks that we want to know about
 FILES=$(git ls-files | grep ".*\.py$")


### PR DESCRIPTION
We shouldn't try to run `pylint` if we aren't touching any `.py` files.
