### PR TITLE
[JS] Turn off 'latedef' restriction in JSHint

### DIFF
--- a/JavaScript/.jshintrc
+++ b/JavaScript/.jshintrc
@@ -10,7 +10,7 @@
 	"curly": true,
 	"eqeqeq": true,
 	"immed": true,
-	"latedef": true,
+	"latedef": false,
 	"maxdepth": 3,
 	"maxlen": 120,
 	"newcap": true,


### PR DESCRIPTION
Explanation with examples here: http://jslinterrors.com/option-jshint-latedef

This disables core & safe behavior of function hoisting in JS. From the example, **"Because declarations in JavaScript are hoisted to the top of the scope in which they occur it is perfectly safe to reference them earlier."** By disallowing function hoisting, we would have to use variable assignment solely to avoid hoisting errors in situations like the following:

``` javascript
// hoisting is safe and native, not an antipattern, but will error with latedef to true
function foo() {
  bar();
}

function bar() {
  foo();
}

// would have to do this more procedural, limiting pattern instead
var foo, bar;
foo = function () { /* ... */ };
bar = function () { /* ... */ };
```

@wikia-frontenders 
