### PR TITLE
adding info about type checking and assertions

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -35,7 +35,7 @@ checks where possible. Inside a function, use ```assert``` for type checking and
 silently fail. **NEVER** pass a string to ```assert```. Example:
 
 ```php
-use Wikia\Util\ErrorChecking\Assert;
+use Wikia\Util\Assert;
 
 function getOtherClass( MyClass $a ) { // will fail automatically if $a is not an instance of MyClass
 	$b = doSomething( $a );


### PR DESCRIPTION
@pchojnacki @drsnyder 
PHP assertions/type hinting from our meeting yesterday. There will be some additional work required in the app repo after this is merged:

~~\- [ ] assert_options(ASSERT_BAIL, 1)~~
~~\- [ ] link assert_options(ASSERT_CALLBACK) to WikiaLogger~~

Also wondering if we should create 2 wrappers here - `assertHard` and `assertSoft`, where we would log + halt execution of the current script or just log and continue. Seems to me like just logging would result in some breakage that would not be immediately apparent. What do you guys think?
