### PR TITLE
Proposal: Pylint updates

### DIFF
--- a/Python/pylintrc
+++ b/Python/pylintrc
@@ -27,7 +27,7 @@ reports = no
 module-rgx = [a-z_][a-z0-9_]+$
 
 # Global variable names
-const-rgx = (([A-Z_][A-Z0-9_]+)|([a-z_][a-z0-9_]+$)|(__.*__))$
+const-rgx = (([A-Z_][A-Z0-9_]+)|([a-z_][a-z0-9_]+)|(__.*__))$
 
 # Classes
 class-rgx = [A-Z_][a-zA-Z0-9]+$


### PR DESCRIPTION
This PR proposes changes to our pylint settings.
1. Disable global-statement warning
   This warning occurs when one attempts to set a variable declared at global in a non-global context.  Reasonable use case for this would be lazy initialization of a module-level variable in a function within that module.
2. Disable abstract-class-not-used warning
   Emitted when an abstract class is not used **within the same module**.  Reasonable use case for this would be declaring an abstract class in one file and a concrete subclass in another.
3. Remove 30 char limit on all names.
   PEP8 states that abbreviations should be avoided unless they are acronyms or initialisms.  Sometimes meaningful names that use full words exceed 30 characters.  That's what auto-complete is for...
4. Update line length to be consistent with PEP8 setting for line length in Wikia guidelines (120).

@jogura, @owend, @nmonterroso 
