### PR TITLE
Using JSLint whitespace conventions for switch statements.

### DIFF
--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -139,6 +139,8 @@ When using `switch` statements:
  - Use `break`, `return` or `throw` for each case other than `default`.
  - The `default` case should always be last.
 
+As with all our whitespace guidelines, switch statements follow JSLint. 
+
 ```javascript
 // bad
 switch (foo) {
@@ -154,15 +156,15 @@ switch (foo) {
 
 // good
 switch (foo) {
-    case 'bar':
-    case 'foobar':
-        x();
-        break;
-    case 'baz':
-        y();
-        break;
-    default:
-        z();
+case 'bar':
+case 'foobar':
+	x();
+	break;
+case 'baz':
+	y();
+	break;
+default:
+	z();
 }
 ```
 


### PR DESCRIPTION
JS-Beautify is already formatting switch statements like this b/c of the `jslint_happy` flag that we have set to true. This will make our guidelines doc match JSLint. 