### PR TITLE
A proposal for line length limits in the PHP guidelines

### DIFF
--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -44,7 +44,7 @@ Conditional tests should not do more than two checks on a single line.  If a con
 one of the following remedies should be used:
  
 * each check should be split into it's own line
-* each check should be split into separate conditionals
+* the single conditional should be split into separate conditionals of two or less checks
 * all checks replaced by a function call
 
 Example:
@@ -55,7 +55,7 @@ if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oa
    // do something
 }
 
-// Good
+// Good - each check split into it's own line
 if ( F::App()->wg->User->can('edit') &&
      F::App()->wg->Skin->getSkinName() == 'oasis' &&
      empty( F::app->wg->NoExternals )
@@ -63,7 +63,7 @@ if ( F::App()->wg->User->can('edit') &&
     // do something
 }
 
-// Good
+// Good - single conditional split into separate conditionals of two or less checks
 if ( !F::App()->wg->User->can('edit') ) {
     return;
 }
@@ -71,7 +71,7 @@ if ( F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExtern
     // do something
 }
 
-// Good
+// Good - checks replaced by a function call
 if ( oasisUserCanEdit() ) {
     // do something
 }

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -1,6 +1,6 @@
 # Wikia PHP Coding Conventions
 
-This file documents Wikia's PHP coding conventions.  To propose changes to this document, please open a pull request
+This file documents Wikia's PHP coding conventions. To propose changes to this document, please open a pull request
 with your changes and tag [@engineers](https://github.com/orgs/Wikia/teams/engineers) for review.
 
 
@@ -24,12 +24,20 @@ found in the [MediaWiki Coding Conventions](http://www.mediawiki.org/wiki/Manual
 
 ### Function Length
 
-Functions should have a limited length.  This limit is loosely defined as one “page”, where a page is the number
-of lines that fit into your editor window or less.  This definition is intentionally vague to allow flexibility but the
-spirit of this guideline is that a developer should not have to scroll vertically to see a full function definition.
+A function definition should be easy for a reader to digest.  This means two things:
 
-If a single function becomes too long it should be broken up into smaller functions which the original function can
+* A function should not do too much
+* A reader should not have to scroll to see the entire definition
+
+For the first point, "Clean Code" ([PDF](https://one.wikia-inc.com/wiki/File:Clean_Code_Book.pdf)) sums this up nicely:
+
+> Functions should do one thing.  They should do it well.  They should do it only.
+
+If a function does more than one thing, it should be split into smaller functions which the original function can
 call.
+
+To the second point, a function should be less than a page in length.  Anything longer almost certainly does more than
+one thing, and forces a reader to scroll to view the whole function.
 
 ### Line Length
 
@@ -117,8 +125,7 @@ function doSomething( MyClass $a ) {
 ### MediaWiki PHP Style Helper
 
 MediaWiki provides a code formatting helper ([stylize.php](https://git.wikimedia.org/blob/mediawiki%2Ftools%2Fcode-utils.git/master/stylize.php))
-which is provided via a submodule in this repo under `mediawiki/tools/code-utils`. To use `stylize.php` on your code
-before you check in:
+which is provided via a sub-module in this repo under `mediawiki/tools/code-utils`. To use `stylize.php` on your code before you check in:
 
 ```sh
 git clone git@github.com:Wikia/guidelines.git /usr/wikia/source/guidelines

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -52,7 +52,7 @@ if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oa
 // Good
 if ( F::App()->wg->User->can('edit') &&
      F::App()->wg->Skin->getSkinName() == 'oasis' &&
-     empty( F::app->wg->NoExternals
+     empty( F::app->wg->NoExternals )
    ) {
     // do something
 }
@@ -66,8 +66,16 @@ if ( F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExtern
 }
 
 // Good
-if ( $this->oasisUserCanEdit() ) {
+if ( oasisUserCanEdit() ) {
     // do something
+}
+
+function oasisUserCanEdit() {
+    return (
+        F::App()->wg->User->can('edit') &&
+        F::App()->wg->Skin->getSkinName() == 'oasis' &&
+        empty( F::app->wg->NoExternals )
+    );
 }
 
 ```

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -51,23 +51,23 @@ Example:
 
 ```php
 // Bad
-if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExternals ) {
+if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app()->wg->NoExternals ) {
    // do something
 }
 
-// Good - each check split into it's own line
-if ( F::App()->wg->User->can( 'edit' ) &&
+// Good - each check split onto its own line
+if ( F::App()->wg->User->isAllowed( 'edit' ) &&
      F::App()->wg->Skin->getSkinName() == 'oasis' &&
-     empty( F::app->wg->NoExternals )
+     empty( F::app()->wg->NoExternals )
    ) {
     // do something
 }
 
 // Good - single conditional split into separate conditionals of two or less checks
-if ( !F::App()->wg->User->can( 'edit' ) ) {
+if ( !F::App()->wg->User->isAllowed( 'edit' ) ) {
     return;
 }
-if ( F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExternals ) {
+if ( F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app()->wg->NoExternals ) {
     // do something
 }
 
@@ -78,9 +78,9 @@ if ( oasisUserCanEdit() ) {
 
 function oasisUserCanEdit() {
     return (
-        F::App()->wg->User->can( 'edit' ) &&
+        F::App()->wg->User->isAllowed( 'edit' ) &&
         F::App()->wg->Skin->getSkinName() == 'oasis' &&
-        empty( F::app->wg->NoExternals )
+        empty( F::app()->wg->NoExternals )
     );
 }
 

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -9,6 +9,8 @@ with your changes and tag [@engineers](https://github.com/orgs/Wikia/teams/engin
 * [Base Rules](#base-rules)
 * [Additional Rules](#additional-rules)
   * [Function Length](#function-length)
+  * [Line Length](#line-length)
+  * [Conditional Logic](#conditional-logic)
   * [Type-Checking and Assertions](#type-checking-and-assertions)
 * [Tools](#tools)
   * [MediaWiki PHP Style Helper](#mediawiki-php-style-helper)
@@ -24,10 +26,51 @@ found in the [MediaWiki Coding Conventions](http://www.mediawiki.org/wiki/Manual
 
 Functions should have a limited length.  This limit is loosely defined as one “page”, where a page is the number
 of lines that fit into your editor window or less.  This definition is intentionally vague to allow flexibility but the
-spirit of this guideline is that a developer should not have to scroll to see a full function definition.
+spirit of this guideline is that a developer should not have to scroll vertically to see a full function definition.
 
 If a single function becomes too long it should be broken up into smaller functions which the original function can
 call.
+
+### Line Length
+
+Lines should be limited to 120 characters.  This limit is chosen as a typical IDE default for line breaks.  The spirit
+of this guideline is that a developer should not have to scroll horizontally to see the end of a line.
+
+If a single line becomes too long, newlines should be added at appropriate breakpoints.
+
+### Conditional Logic
+
+Conditional tests should not do more than two checks on a single line.  If a conditional requires more than two checks,
+each check should be split into it's own line, split into separate conditionals, or replaced by a function call:
+
+```php
+// Bad
+if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExternals ) {
+   // do something
+}
+
+// Good
+if ( F::App()->wg->User->can('edit') &&
+     F::App()->wg->Skin->getSkinName() == 'oasis' &&
+     empty( F::app->wg->NoExternals
+   ) {
+    // do something
+}
+
+// Good
+if ( !F::App()->wg->User->can('edit') ) {
+    return;
+}
+if ( F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExternals ) {
+    // do something
+}
+
+// Good
+if ( $this->oasisUserCanEdit() ) {
+    // do something
+}
+
+```
 
 ### Type-Checking and Assertions
 

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -56,7 +56,7 @@ if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oa
 }
 
 // Good - each check split into it's own line
-if ( F::App()->wg->User->can('edit') &&
+if ( F::App()->wg->User->can( 'edit' ) &&
      F::App()->wg->Skin->getSkinName() == 'oasis' &&
      empty( F::app->wg->NoExternals )
    ) {
@@ -64,7 +64,7 @@ if ( F::App()->wg->User->can('edit') &&
 }
 
 // Good - single conditional split into separate conditionals of two or less checks
-if ( !F::App()->wg->User->can('edit') ) {
+if ( !F::App()->wg->User->can( 'edit' ) ) {
     return;
 }
 if ( F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app->wg->NoExternals ) {
@@ -78,7 +78,7 @@ if ( oasisUserCanEdit() ) {
 
 function oasisUserCanEdit() {
     return (
-        F::App()->wg->User->can('edit') &&
+        F::App()->wg->User->can( 'edit' ) &&
         F::App()->wg->Skin->getSkinName() == 'oasis' &&
         empty( F::app->wg->NoExternals )
     );

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -43,7 +43,7 @@ If a single line becomes too long, newlines should be added at appropriate break
 Conditional tests should not do more than two checks on a single line.  If a conditional requires more than two checks,
 one of the following remedies should be used:
  
-* each check should be split into it's own line
+* each check should be split onto its own line
 * the single conditional should be split into separate conditionals of two or less checks
 * all checks replaced by a function call
 

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -51,7 +51,7 @@ Example:
 
 ```php
 // Bad
-if ( F::App()->wg->User->can('edit') && F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app()->wg->NoExternals ) {
+if ( F::App()->wg->User->can( 'edit' ) && F::App()->wg->Skin->getSkinName() == 'oasis' && empty( F::app()->wg->NoExternals ) {
    // do something
 }
 

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -41,7 +41,13 @@ If a single line becomes too long, newlines should be added at appropriate break
 ### Conditional Logic
 
 Conditional tests should not do more than two checks on a single line.  If a conditional requires more than two checks,
-each check should be split into it's own line, split into separate conditionals, or replaced by a function call:
+one of the following remedies should be used:
+ 
+* each check should be split into it's own line
+* each check should be split into separate conditionals
+* all checks replaced by a function call
+
+Example:
 
 ```php
 // Bad


### PR DESCRIPTION
I believe many people follow line length limits at Wikia so it would be nice to formalize these a bit.  This pull request adds guidelines addressing two issues around long lines.  First how long a line should be in general and second what to do about long conditional statements specifically.

Note that this pull request is based on the "Reformat" branch.  Therefore this pull request is dependent on that branches pull request (https://github.com/Wikia/guidelines/pull/59).  This was done to separate these two changes and hopefully doesn't introduce more confusion.  If both pull requests are accepted, this pull request should be pulled first.

@Wikia/engineers 