### PR TITLE
PHP bracket array syntax

### DIFF
--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -98,7 +98,8 @@ function oasisUserCanEdit() {
 
 PHP supports 2 forms of syntax for arrays, ```array()``` and the shorter ```[]``` which was introduced in PHP 5.4.
 
-Examples of how to use the first version are numerous in MediaWiki's coding conventions. Specifically, padding should be added after the opening parenthesis and before the closing parenthesis.
+Examples of how to use the first version are numerous in MediaWiki's coding conventions. Specifically, padding should be
+added after the opening parenthesis and before the closing parenthesis.
 
 ```php
 // good
@@ -109,7 +110,8 @@ $foo = array('bar', 'baz', 'zed');
 
 ```
 
-The shorter bracket syntax is not covered by these conventions, but should follow a similar practice. Padding should be added for both array definitions, as well as anonymous arrays. Note that padding should not however be applied to array indexing.
+The shorter bracket syntax is not covered by these conventions, but should follow a similar practice. Padding should be
+added for both array definitions, as well as anonymous arrays. Note that padding should not be applied to array indexing.
 
 ```php
 // good

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -11,6 +11,7 @@ with your changes and tag [@engineers](https://github.com/orgs/Wikia/teams/engin
   * [Function Length](#function-length)
   * [Line Length](#line-length)
   * [Conditional Logic](#conditional-logic)
+  * [Array Syntax](#array-syntax)
   * [Type-Checking and Assertions](#type-checking-and-assertions)
 * [Tools](#tools)
   * [MediaWiki PHP Style Helper](#mediawiki-php-style-helper)

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -94,6 +94,35 @@ function oasisUserCanEdit() {
 
 ```
 
+### Array Syntax
+
+PHP supports 2 forms of syntax for arrays, ```array()``` and the shorter ```[]``` which was introduced in PHP 5.4.
+
+Examples of how to use the first version are numerous in MediaWiki's coding conventions. Specifically, padding should be added after the opening parenthesis and before the closing parenthesis.
+
+```php
+// good
+$foo = array( 'bar', 'baz' 'zed' );
+
+// bad
+$foo = array('bar', 'baz', 'zed');
+
+```
+
+The shorter bracket syntax is not covered by these conventions, but should follow a similar practice. Padding should be added for both array definitions, as well as anonymous arrays. Note that padding should not however be applied to array indexing.
+
+```php
+// good
+$foo = [ 'bar', 'baz', 'zed' ];
+myFunctionCall( [ 'needs', 'an', 'array' ] );
+$foo['theDude'] = 'abides';
+
+// bad
+$foo = ['bar', 'baz', 'zed'];
+myFunctionCall( ['needs', 'an', 'array'] );
+$foo[ 'theDude' ] = 'abides';
+```
+
 ### Type-Checking and Assertions
 
 When validating function input types, prefer [type hinting](http://php.net/manual/en/language.oop5.typehinting.php) over

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -103,7 +103,7 @@ added after the opening parenthesis and before the closing parenthesis.
 
 ```php
 // good
-$foo = array( 'bar', 'baz' 'zed' );
+$foo = array( 'bar', 'baz', 'zed' );
 
 // bad
 $foo = array('bar', 'baz', 'zed');

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -97,21 +97,11 @@ function oasisUserCanEdit() {
 ### Array Syntax
 
 PHP supports 2 forms of syntax for arrays, ```array()``` and the shorter ```[]``` which was introduced in PHP 5.4.
+At Wikia we favor the 2nd version and actively try and convert old style arrays to the new style. If you encounter
+old style arrays during development, please convert them to the new style.
 
-Examples of how to use the first version are numerous in MediaWiki's coding conventions. Specifically, padding should be
-added after the opening parenthesis and before the closing parenthesis.
-
-```php
-// good
-$foo = array( 'bar', 'baz', 'zed' );
-
-// bad
-$foo = array('bar', 'baz', 'zed');
-
-```
-
-The shorter bracket syntax is not covered by these conventions, but should follow a similar practice. Padding should be
-added for both array definitions, as well as anonymous arrays. Note that padding should not be applied to array indexing.
+In regards to syntax, padding should be added for both array definitions, as well as anonymous arrays. Note that
+padding should not be applied to array indexing.
 
 ```php
 // good


### PR DESCRIPTION
This PR formalizes guidelines for PHP's alternate bracket array syntax. It seems to be a convention which was favored throughout the code base, but this adds it as an official Wikia convention. The confluence question raising whether this should be added as a convention and the responses that followed can be found [here](https://wikia-inc.atlassian.net/wiki/questions/19136541/coding-convention-for-bracket-array-syntax-in-php).

cc @Wikia/engineers 