### PR TITLE
Add convention in js guidelines for using bind over proxy

### DIFF
--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -28,6 +28,7 @@ This styleguide defines the JavaScript coding conventions at Wikia. While it is 
      * [Chained Method Calls](#chained-method-calls)
   * [Caching jQuery Objects](#caching-jquery-objects)
   * [Storing Context in a Local Variable](#storing-context-in-a-local-variable)
+  * [Setting Context using .bind()](#setting-context-using-bind-)
   * [Comments](#comments)
   * [Naming Conventions](#naming-conventions)
      * [Variables](#variables)
@@ -537,6 +538,33 @@ function example() {
 		self.doSomething();
 	});
 }
+```
+
+#### Setting Context Using .bind()
+
+As an alternative to storing context using a local variable as shown above, you can also use the `.bind()` method on
+functions. This creates a new function that when called has its `this` keyword set to the provided value. jQuery
+provides similar functionality using `$.proxy()` which was widely used before `.bind()` became a standard. They differ in that
+`.bind()` creates a permanent connection, whereas `$.proxy()` can be broken. `.bind()` should cover most use cases and
+therefore should be favored. Please convert existing uses of `$.proxy()` to `.bind()` when possible.
+
+Example:
+```javascript
+function example() {
+	$myObj.on('click', function () {
+		// some code...
+		this.doSomething();
+	}.bind(this));
+};
+// or
+var exampleObject = {
+	init: function () {
+		$('button').on('click', this.callBack.bind(this))
+	},
+	callBack: function () {
+		// do some stuff
+	}
+};
 ```
 
 #### AMD Modules

--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -543,10 +543,10 @@ function example() {
 #### Setting Context Using .bind()
 
 As an alternative to storing context using a local variable as shown above, you can also use the `.bind()` method on
-functions. This creates a new function that when called has its `this` keyword set to the provided value. jQuery
-provides similar functionality using `$.proxy()` which was widely used before `.bind()` became a standard. They differ in that
-`.bind()` creates a permanent connection, whereas `$.proxy()` can be broken. `.bind()` should cover most use cases and
-therefore should be favored. Please convert existing uses of `$.proxy()` to `.bind()` when possible.
+functions. This creates a new function that when called has its `this` keyword set to the provided value. jQuery provides
+similar functionality using `$.proxy()` which was widely used before `.bind()` became a standard. `.bind()` is native JS, and
+supported in all our supported browsers, so it is the preferred method over jQuery. Please convert existing
+uses of `$.proxy()` to `.bind()` when possible.
 
 Example:
 ```javascript

--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -559,9 +559,9 @@ function example() {
 // or
 var exampleObject = {
 	init: function () {
-		$('button').on('click', this.callBack.bind(this))
+		$('button').on('click', this.callback.bind(this));
 	},
-	callBack: function () {
+	callback: function () {
 		// do some stuff
 	}
 };


### PR DESCRIPTION
Currently we don't have a convention which it comes to setting context with `$.proxy()` or `.bind()`. Most of the time these 2 are synonymous, and without an official preference we end up with 2 ways of doing the same thing throughout our codebase. This PR hopes to clarify a preference for `.bind()`, since is native js rather than part of a library.