### PR TITLE
skip commit hooks when merging or cherry-picking

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -11,6 +11,18 @@ else
   REVISION=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
+# if we are in the middle of merging skip hooks
+MERGING=$(git rev-parse MERGE_HEAD 2>&1)
+if [[ $? == 0 ]]; then
+  exit 0
+fi
+
+# if we are in the middle of merging skip hooks
+PICKING=$(git rev-parse CHERRY_PICK_HEAD 2>&1)
+if [[ $? == 0 ]]; then
+  exit 0
+fi
+
 # determine which files have actually changed
 FILES=$(git diff --cached --name-only --diff-filter=ACM "${REVISION}")
 


### PR DESCRIPTION
We ran into this issue when running git hooks while merging a branch with conflicts.  The best fix seems to be to just skip running the hooks at that point.   The "conflict" resolution code won't be checked but all the other code will have already been checked.  

https://github.com/brigade/overcommit/issues/52