### PR TITLE
Allow and encourage trailing commas

### DIFF
--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -11,6 +11,7 @@ This styleguide defines the JavaScript coding conventions at Wikia. While it is 
 * [Language Rules](#language-rules)
   * [Early Returns](#early-returns)
   * [Semicolons](#semicolons)
+  * [Trailing Colons](#trailing-colons)
   * [Function-declarations Within Blocks](#function-declarations-within-blocks)
   * [Try/Catch Blocks](#trycatch-blocks)
   * [Switch Statements](#switch-statements)
@@ -84,6 +85,29 @@ var x = y; myFunc();
 // good:
 var x = y;
 myFunc();
+```
+
+### Trailing Colons
+
+Trailing commas in object literals are legal in ECMAScript 5, trailing commas in arrays are ignored.
+
+//good
+```js
+var obj = {
+  first: 'Jane',
+  last: 'Doe',
+  age: 40,  // trailing comma
+};
+```
+
+//good
+```js
+var arr = [
+  'a',
+  'b',
+  'c',
+];
+arr.length === 3
 ```
 
 ### Function Declarations Within Blocks

--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -91,8 +91,16 @@ myFunc();
 
 Trailing commas in object literals are legal in ECMAScript 5, trailing commas in arrays are ignored.
 
-//good
+In object:
 ```js
+//ok
+var obj = {
+  first: 'Jane',
+  last: 'Doe',
+  age: 40  // no trailing comma
+};
+
+//better
 var obj = {
   first: 'Jane',
   last: 'Doe',
@@ -100,8 +108,9 @@ var obj = {
 };
 ```
 
-//good
+In array:
 ```js
+//good
 var arr = [
   'a',
   'b',

--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -11,7 +11,7 @@ This styleguide defines the JavaScript coding conventions at Wikia. While it is 
 * [Language Rules](#language-rules)
   * [Early Returns](#early-returns)
   * [Semicolons](#semicolons)
-  * [Trailing Colons](#trailing-colons)
+  * [Trailing Commas](#trailing-commas)
   * [Function-declarations Within Blocks](#function-declarations-within-blocks)
   * [Try/Catch Blocks](#trycatch-blocks)
   * [Switch Statements](#switch-statements)
@@ -87,7 +87,7 @@ var x = y;
 myFunc();
 ```
 
-### Trailing Colons
+### Trailing Commas
 
 Trailing commas in object literals are legal in ECMAScript 5, trailing commas in arrays are ignored.
 


### PR DESCRIPTION
According to http://www.2ality.com/2013/07/trailing-commas.html
and http://rauschma.github.io/js-feature-matrix/

Trailing commas are allowed in ES5
and are only not working in IE < 8

Spec:
http://ecma262-5.com/ELS5_HTML.htm#Section_11.1.5
http://ecma262-5.com/ELS5_HTML.htm#Section_11.1.4

Our current support for IE says IE 11+
and traffic from IE < 8 is on level of 0.00% of all trafic

Reasoning:
1. smaller diffs in VCS
2. easier reorder of elements