### PR TITLE
PR description guildelines

### DIFF
--- a/Process/PullRequests.md
+++ b/Process/PullRequests.md
@@ -38,7 +38,7 @@ Each PR will:
      thumbnail under the original dir in the thumb path”.
   3. Contain a description (or link to a description, i.e. Jira ticket) written using complete sentences of the changes being
      made and any context necessary to understand them. Example:
-     https://github.com/Wikia/vignette/pull/15. 
+     https://github.com/Wikia/vignette/pull/15. Description field should not be empty. 
        1. [optional] An @ message to the stakeholders and reviewers of the PR.
           Example: “/cc @nmonterroso”.
        2. If the PR contains production SQL changes the @SQLReview tag should be

--- a/Process/PullRequests.md
+++ b/Process/PullRequests.md
@@ -38,7 +38,7 @@ Each PR will:
      thumbnail under the original dir in the thumb path”.
   3. Contain a description (or link to a description, i.e. Jira ticket) written using complete sentences of the changes being
      made and any context necessary to understand them. Example:
-     https://github.com/Wikia/vignette/pull/15. Description field should not be empty. 
+     https://github.com/Wikia/vignette/pull/15. Description field should not be empty, and linked resources must meet the above standards. 
        1. [optional] An @ message to the stakeholders and reviewers of the PR.
           Example: “/cc @nmonterroso”.
        2. If the PR contains production SQL changes the @SQLReview tag should be

--- a/Process/PullRequests.md
+++ b/Process/PullRequests.md
@@ -36,9 +36,9 @@ Each PR will:
   2. Include a title that provides a one sentence overview of the purpose of the
      PR. Abbreviations can be used when necessary. Example: “PLAT-433 put the
      thumbnail under the original dir in the thumb path”.
-  3. Contain a description written using complete sentences of the changes being
+  3. Contain a description (or link to a description, i.e. Jira ticket) written using complete sentences of the changes being
      made and any context necessary to understand them. Example:
-     https://github.com/Wikia/vignette/pull/15.
+     https://github.com/Wikia/vignette/pull/15. 
        1. [optional] An @ message to the stakeholders and reviewers of the PR.
           Example: “/cc @nmonterroso”.
        2. If the PR contains production SQL changes the @SQLReview tag should be


### PR DESCRIPTION
Specifying that we can provide the same quality of description via link as opposed to in the body of the description itself. 