### PR TITLE
Follow MW conventions regarding lines continuation

### DIFF
--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -65,9 +65,9 @@ if ( F::App()->wg->User->can( 'edit' ) && F::App()->wg->Skin->getSkinName() == '
 }
 
 // Good - each check split onto its own line
-if ( F::App()->wg->User->isAllowed( 'edit' ) &&
-     F::App()->wg->Skin->getSkinName() == 'oasis' &&
-     empty( F::app()->wg->NoExternals )
+if ( F::App()->wg->User->isAllowed( 'edit' )
+     && F::App()->wg->Skin->getSkinName() == 'oasis'
+     && empty( F::app()->wg->NoExternals )
    ) {
     // do something
 }
@@ -86,10 +86,9 @@ if ( oasisUserCanEdit() ) {
 }
 
 function oasisUserCanEdit() {
-    return (
-        F::App()->wg->User->isAllowed( 'edit' ) &&
-        F::App()->wg->Skin->getSkinName() == 'oasis' &&
-        empty( F::app()->wg->NoExternals )
+    return ( F::App()->wg->User->isAllowed( 'edit' )
+        && F::App()->wg->Skin->getSkinName() == 'oasis'
+        && empty( F::app()->wg->NoExternals )
     );
 }
 


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Manual:Coding_conventions#Line_continuation

The suggestion is about moving the logical operators in conditions to the beginning of a line and keeping the first check in the same line as a command. I personally find it helpful when I grep our codebase or use the Refactor mechanism in PHP Storm. If a piece of a code is formatted this way every line has a clear indicator of being part of a logical condition.
