### PR TITLE
Whitespace guidelines also apply to JSON

### DIFF
--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -262,7 +262,7 @@ Style rules help us write easy to read, well documented, and consistent code.
 
 ### White Space Guidelines
 
-Our whitespace guidelines are based on JSLint. There are also some rules listed below that are in addition JSLint.
+These guidelines also apply to JSON, where applicable. Our whitespace guidelines are based on JSLint. There are also some rules listed below that are in addition JSLint.
 
 - Indent with tabs.
 - No whitespace at the end of line or on blank lines.

--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -262,7 +262,7 @@ Style rules help us write easy to read, well documented, and consistent code.
 
 ### White Space Guidelines
 
-These guidelines also apply to JSON, where applicable. Our whitespace guidelines are based on JSLint. There are also some rules listed below that are in addition JSLint.
+Our whitespace guidelines are based on JSLint. There are also some rules listed below that are in addition JSLint. For JSON files, indent with spaces instead of tabs.
 
 - Indent with tabs.
 - No whitespace at the end of line or on blank lines.


### PR DESCRIPTION
I wasn't sure if the whitespace guidelines apply to JSON, since it is not only used in JS. I've added a clause to make it explicit.