### PR TITLE
Make our guidelines consistent with the MW ones

### DIFF
--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -55,6 +55,7 @@ one of the following remedies should be used:
 * each check should be split onto its own line
 * the single conditional should be split into separate conditionals of two or less checks
 * all checks replaced by a function call
+* the operator separating the two lines may be placed on either the following line or the preceding line. An operator placed on the following line is more visible and so is more often used when the author wants to draw attention to it.
 
 Example:
 
@@ -65,9 +66,9 @@ if ( F::App()->wg->User->can( 'edit' ) && F::App()->wg->Skin->getSkinName() == '
 }
 
 // Good - each check split onto its own line
-if ( F::App()->wg->User->isAllowed( 'edit' ) &&
-     F::App()->wg->Skin->getSkinName() == 'oasis' &&
-     empty( F::app()->wg->NoExternals )
+if ( F::App()->wg->User->isAllowed( 'edit' )
+     && F::App()->wg->Skin->getSkinName() == 'oasis'
+     && empty( F::app()->wg->NoExternals )
    ) {
     // do something
 }
@@ -86,11 +87,9 @@ if ( oasisUserCanEdit() ) {
 }
 
 function oasisUserCanEdit() {
-    return (
-        F::App()->wg->User->isAllowed( 'edit' ) &&
-        F::App()->wg->Skin->getSkinName() == 'oasis' &&
-        empty( F::app()->wg->NoExternals )
-    );
+    return F::App()->wg->User->isAllowed( 'edit' )
+        && F::App()->wg->Skin->getSkinName() == 'oasis'
+        && empty( F::app()->wg->NoExternals );
 }
 
 ```


### PR DESCRIPTION
Since it raises unnecessary discussions - can we unify our guidelines for logical operators with the [MediaWiki ones](https://www.mediawiki.org/wiki/Manual:Coding_conventions#Line_continuation)?

/cc: @garthwebb @macbre @Grunny 
