### PR TITLE
Change switch case indent

### DIFF
--- a/JavaScript/.eslintrc
+++ b/JavaScript/.eslintrc
@@ -134,7 +134,7 @@
     "func-style": 0,
     "id-length": 0,
     "id-match": 0,
-    "indent": [2, "tab", {"VariableDeclarator": 1}],
+    "indent": [2, "tab", {"VariableDeclarator": 1, "SwitchCase": 1}],
     "jsx-quotes": 0,
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
     "lines-around-comment": [0, { "beforeBlockComment": true}],

--- a/JavaScript/CodingConventions.md
+++ b/JavaScript/CodingConventions.md
@@ -180,32 +180,32 @@ When using `switch` statements:
  - Use `break`, `return` or `throw` for each case other than `default`
  - The `default` case should always be last.
 
-As with all our whitespace guidelines, switch statements follow JSLint.
+Use 1 tab indentation for `case` / `default` statements.
 
 ```javascript
 // bad
 switch (foo) {
-    default:
-        z();
-    case 'bar':
-    case 'foobar':
-        x();
-        break;
-    case 'baz':
-        y();
+case 'bar':
+case 'foobar':
+    x();
+    break;
+case 'baz':
+    y();
+default:
+    z();
 }
 
 // good
 switch (foo) {
-case 'bar':
-case 'foobar':
-	x();
-	break;
-case 'baz':
-	y();
-	break;
-default:
-	z();
+	case 'bar':
+	case 'foobar':
+		x();
+		break;
+	case 'baz':
+		y();
+		break;
+	default:
+		z();
 }
 ```
 


### PR DESCRIPTION
As a result of discussion around Mercury ESLint rules I'd like to propose changing indentation rules for `case` and `default` in `switch` statement.
 
The issue was put on Mercury TODOs list:
https://wikia-inc.atlassian.net/wiki/display/MER/Mercury+TODOs

Here is a PR for Mercury changing ESLint rules for entire mercury repo:
https://github.com/Wikia/mercury/pull/2048