### PR TITLE
Update url for code-utils repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mediawiki/tools/code-utils"]
 	path = mediawiki/tools/code-utils
-	url = https://git.wikimedia.org/git/mediawiki/tools/code-utils.git
+	url = https://phabricator.wikimedia.org/diffusion/MCUT/code-utils.git

--- a/PHP/CodingConventions.md
+++ b/PHP/CodingConventions.md
@@ -167,7 +167,7 @@ function doSomething( MyClass $a ) {
 
 ### MediaWiki PHP Style Helper
 
-MediaWiki provides a code formatting helper ([stylize.php](https://git.wikimedia.org/blob/mediawiki%2Ftools%2Fcode-utils.git/master/stylize.php))
+MediaWiki provides a code formatting helper ([stylize.php](https://phabricator.wikimedia.org/diffusion/MCUT/browse/master/stylize.php))
 which is provided via a sub-module in this repo under `mediawiki/tools/code-utils`. To use `stylize.php` on your code before you check in:
 
 ```sh


### PR DESCRIPTION
Looks like the url for the code-utils repo at `git.wikimedia.org` has moved to  `phabricator.wikimedia.org`.

The other steps in the [PHP Coding Conventions](https://github.com/Wikia/guidelines/blob/master/PHP/CodingConventions.md#tools) are still accurate and work with this change.
