### PR TITLE
Allow wildcard imports

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -10,6 +10,7 @@ Wikia follows [Google guidelines](https://google.github.io/styleguide/javaguide.
 
 With following addition:
  - 100 column limit should be used by all projects, with exceptions noted in Google guidelines.
+ - wildcard import statements should be preferred if you are importing more than three classes from the same package.
 
 ## Coding Conventions
 

--- a/Java/formatter/intellij-java-google-style-pre-14.1.xml
+++ b/Java/formatter/intellij-java-google-style-pre-14.1.xml
@@ -12,8 +12,8 @@
       <option name="USE_RELATIVE_INDENTS" value="false" />
     </value>
   </option>
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="4" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="4" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
       <package name="" withSubpackages="true" static="true" />

--- a/Java/formatter/intellij-java-google-style.xml
+++ b/Java/formatter/intellij-java-google-style.xml
@@ -1,6 +1,6 @@
 <code_scheme name="GoogleStyle-14.1">
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="4" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="4" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
       <package name="" withSubpackages="true" static="true" />


### PR DESCRIPTION
If you are importing more than a handful of classes from the same package, import the whole package. Masses of individual imports from a single package are just clutter and hide the intent of your code.

See also, five minutes into this video:  https://vimeo.com/105758303

I updated the default IDEA configs, but I don't don't believe in eclipse so someone else will have to fix that.