### PR TITLE
SER | Increase line width from 100 to 120 chars

### DIFF
--- a/Java/formatter/intellij-java-google-style.xml
+++ b/Java/formatter/intellij-java-google-style.xml
@@ -15,7 +15,7 @@
       <emptyLine />
     </value>
   </option>
-  <option name="RIGHT_MARGIN" value="100" />
+  <option name="RIGHT_MARGIN" value="120" />
   <option name="JD_P_AT_EMPTY_LINES" value="false" />
   <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />


### PR DESCRIPTION
In our .editorconfig we've got a limit of 120 characters, so developers using editor config plugin for IntelliJ may have had it overridden already.

Google has chosen our previous limit 100 as a compromise between 80 lines and 120.
I'd posit that while normally we keep lines fairly short, there are cases the 120 limit will be convenient.
`private static final String CONSTANT_WITH_NAME = "something almost fitting 120 chars"`

It also shouldn't be of much of an issue in case of vertical and Mac screens.