### PR TITLE
Prop Types guidelines

### DIFF
--- a/Fandom Creator/JavaScript.md
+++ b/Fandom Creator/JavaScript.md
@@ -70,3 +70,19 @@ import './BaseCard.scss';
 ```
 
 Note that alphebatizing is based on the import directory, then file name.
+
+## Prop Types
+
+PropTypes **SHOULD** be listed at the bottom of every file - where props are made available - before the class export. Regardless of whether it is a React class component or a functional component. Default props **SHOULD** be listed afterwards if required. These **SHOULD** also be listed in alphabetical order.
+
+```
+Nav.propTypes = {
+    height: PropTypes.number,
+};
+
+Nav.defaultProps = {
+    height: 35,
+};
+
+export default Nav;
+```

--- a/Fandom Creator/JavaScript.md
+++ b/Fandom Creator/JavaScript.md
@@ -6,6 +6,7 @@ These coding conventions are for JavaScript inside the Fandom Creator Repo.
 | --- | ----------- |
 | [Binding this](#binding-this) | MUST |
 | [Static Data Within a Class](#static-data-within-a-class) | SHOULD |
+| [Prop Types](#prop-types) | SHOULD |
 
 ## Binding this
 


### PR DESCRIPTION
## Description
We have been fairly inconsistent with propTypes. Sometimes they are found in the class itself, sometimes at the bottom of the file. The main advantage of this guideline is being able to quickly figure out what propTypes are required or passable as they will always be at the bottom.

The reason for choosing the bottom is because functional or return only components cannot define propTypes inside the class, whereas you can do so inside React.Components. By always listing them at the bottom there will be a consistent place to find propTypes (and defaultProps) regardless of the type of component or class.

## By when to collect feedback?
18-01-2019

## Who Might Be Interested?
@Wikia/cake