### PR TITLE
Updating PR template and FC guidelines README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@
 <date>
 
 ## Who Might Be Interested?
-@Wikia/cake
+<person or team>

--- a/Fandom Creator/README.md
+++ b/Fandom Creator/README.md
@@ -12,6 +12,7 @@ If you'd like to update the guidelines, please submit a PR and tag @wikia/cake. 
 Pull requests should contain a description of the new guideline and a date by which all feedback should be given. Pull requests can be merged on that date as long as: 
 * At least one person has approved the PR or added an "LGTM" (looks good to me) comment
 * All requests for change have been addressed and/or all parties have agreed to disagree.
+* If there are differences in opinion, the majority rules. 
 
 ## Updating legacy code to reflect new guidelines
 

--- a/Fandom Creator/README.md
+++ b/Fandom Creator/README.md
@@ -5,7 +5,20 @@ These coding conventions refer to the [Fandom Creator](https://github.com/Wikia/
 * [Javascript](JavaScript.md)
 * [SCSS](SCSS.md)
 
-## Contributing
+## Contributing to the Guidelines
 
 If you'd like to update the guidelines, please submit a PR and tag @wikia/cake. Also mention it in the #cake-team-tech slack channel. 
 
+Pull requests should contain a description of the new guideline and a date by which all feedback should be given. Pull requests can be merged on that date as long as: 
+* At least one person has approved the PR or added an "LGTM" (looks good to me) comment
+* All requests for change have been addressed and/or all parties have agreed to disagree.
+
+## Updating legacy code to reflect new guidelines
+
+This can be done in a number of ways.
+
+### Clean up as you go
+It is important that we take the opportunity to refactor code that doesn't meet our guidelines as we see it in the code base. If a PR has gotten too large or you're running out of time, it's okay to leave legacy code as is. Please use your best judgement.
+
+### Create a ticket to do a sweeping change
+It can be a boon to productivity to have the entire code base adhere to a certain guideline. If you think this might be the case, please create a ticket and let the product owner know, even if we don't get to it right away.


### PR DESCRIPTION
## Description
The PR template actually works for the whole guidelines repo so I modified it a bit and moved it to the `.github` directory.

Also added some notes from the [code club doc](https://docs.google.com/document/d/1Yx5dzNhy8HZwMXD40Sco5kgEMKQaWn4b75wv6ImrL5c/edit) to the README. 

## By when to collect feedback?
1/19/2019

## Who Might Be Interested?
@Wikia/cake 
